### PR TITLE
Fixed audit warnings for npm and copy of homepage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1727,9 +1727,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -1766,9 +1766,9 @@
       }
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -1845,9 +1845,9 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,7 +9,7 @@ export default function Home() {
     <>
       <Head>
         <title>SLE Base Container Images</title>
-        <meta name='description' content='Minimal SUSE Linux Enterprise Server 15-based images that you can use to develop, deploy, and share applications' />
+        <meta name='description' content='Secure software innovation' />
         {/** 👀 Replace with your custom favicon.ico */}
         <link rel='icon' href='/bci/favicon.ico' />
       </Head>
@@ -23,19 +23,14 @@ export default function Home() {
                 <img className='w-90 fill-current dark:hidden my-4' src='/bci/SLE_BCI-pos.png' alt='' />
                 <img className='w-90 fill-current hidden dark:block my-4' src='/bci/SLE_BCI-neg.png' alt='' />
               </div>
-              <p className='text-2xl font-thin text-left text-secondary-dark dark:text-primary'>Base containers to build and run your applications</p>
-
-              <p className='mt-4'>
-                Secure supply chain. Designed to be minimal. Base and programming language images. Use under your applications and in CI.
-              </p>
             </motion.div>
 
-            <div className='col-span-2'>
-              <h2 className='text-secondary-dark dark:text-primary font-light text-lg'>TBD</h2>
-              <p className='text-bold my-4 text-sm'>More TBD</p>
-              <motion.p className='grid grid-flow-row gap-4 text-sm font-thin' initial='hidden' animate='visible' variants={motionListItems}>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-              </motion.p>
+            <div className='col-span-2' >
+              <h2 className='text-secondary-dark dark:text-primary font-light text-lg'>Your stable foundation for software innovation</h2>
+              <p className='text-bold my-4 text-sm'>Build, deploy, and scale your applications with confidence.</p>  
+              <a href="https://registry.suse.com" className="inline-flex items-center h-8 px-4 m-2 text-sm text-white transition-colors duration-150 bg-[#2453FF] rounded-lg focus:shadow-outline hover:bg-[#2453FF]">
+                Get started
+              </a>
             </div>
 
           </div>
@@ -45,50 +40,50 @@ export default function Home() {
         <div className='grid gap-6 mx-auto w-5/6 2xl:w-4/6'>
           <div className='grid grid-flow-row md:grid-cols-3 gap-14 mb-10'>
             <div>
-              <h2 className='text-secondary-dark dark:text-primary font-light text-lg'>Easy To Use</h2>
-              <p className='text-bold my-4 text-sm'>Use like other popular base images.</p>
+              <h2 className='text-secondary-dark dark:text-primary font-light text-lg'>Effortless</h2>
+              <p className='text-bold my-4 text-sm'>Easy to use</p>
               <motion.p className='grid grid-flow-row gap-4 text-sm font-thin' initial='hidden' animate='visible' variants={motionListItems}>
-                Use in your Dockerfiles and with common tools like Visual Studio Code or Docker. 
+                Use it just like any other container image in a Dockerfile or directly from our registry.
               </motion.p>
             </div>
 
             <div>
-              <h2 className='text-secondary-dark dark:text-primary font-light text-lg'>Supply Chain Security</h2>
-              <p className='text-bold my-4 text-sm'>Secure, signed, and attested builds.</p>
+              <h2 className='text-secondary-dark dark:text-primary font-light text-lg'>Secure</h2>
+              <p className='text-bold my-4 text-sm'>Signed and attested builds.</p>
               <motion.p className='grid grid-flow-row gap-4 text-sm font-thin' initial='hidden' animate='visible' variants={motionListItems}>
-                Built using SUSE&apos;s build service which is designed to meet some of the strictest secure build certifications. Signed and verifiable with Sigstore&apos;s cosign.
+                Signed and verifiable with Sigstore&apos;s cosign. Fortressed by SUSE&apos;s robust build service.
               </motion.p>
             </div>
 
             <div>
-              <h2 className='text-secondary-dark dark:text-primary font-light text-lg'>Fast CVE Responses</h2>
-              <p className='text-bold my-4 text-sm'>Continuously updated with vulnerability fixes.</p>
+              <h2 className='text-secondary-dark dark:text-primary font-light text-lg'>Resilient</h2>
+              <p className='text-bold my-4 text-sm'>Swift CVE responses</p>
               <motion.p className='grid grid-flow-row gap-4 text-sm font-thin' initial='hidden' animate='visible' variants={motionListItems}>
-                Vulnerabilities happen. BCIs are continuously updated to fix known CVEs. The same policy that applies to SLE applies to these BCIs.
+                Vulnerabilities happen. BCIs are continuously updated to fix known CVEs.
               </motion.p>
             </div>
 
             <div>
               <h2 className='text-secondary-dark dark:text-primary font-light text-lg'>Stable</h2>
-              <p className='text-bold my-4 text-sm'>Built on the stability of SLE</p>
+              <p className='text-bold my-4 text-sm'>Built on the dependability of SLE</p>
               <motion.p className='grid grid-flow-row gap-4 text-sm font-thin' initial='hidden' animate='visible' variants={motionListItems}>
-                Stability in your environment matters. With the base and language images you get a stability underlying environment while being able to keep up language versions.
+                With SLE BCI, ensure a rock solid foundation while keeping up with the changes in versions of technologies and/or languages.
               </motion.p>
             </div>
 
             <div>
-              <h2 className='text-secondary-dark dark:text-primary font-light text-lg'>Supported</h2>
-              <p className='text-bold my-4 text-sm'>Support that goes beyond SLE</p>
+              <h2 className='text-secondary-dark dark:text-primary font-light text-lg'>Support</h2>
+              <p className='text-bold my-4 text-sm'>Go above and beyond SLE</p>
               <motion.p className='grid grid-flow-row gap-4 text-sm font-thin' initial='hidden' animate='visible' variants={motionListItems}>
-                You can get support for the BCIs running on SLE Micro, SLES, RKE2, K3s, AKS, GKE, EKS, and more.
+                With support for BCIs running on SLE Micro, SLES, RKE2, K3s, AKS, GKE, EKS, and more, embrace true distribution agnosticity! 
               </motion.p>
             </div>
 
             <div>
-              <h2 className='text-secondary-dark dark:text-primary font-light text-lg'>Small</h2>
-              <p className='text-bold my-4 text-sm'>Small images available.</p>
+              <h2 className='text-secondary-dark dark:text-primary font-light text-lg'>Minimal</h2>
+              <p className='text-bold my-4 text-sm'>Keep it simple</p>
               <motion.p className='grid grid-flow-row gap-4 text-sm font-thin' initial='hidden' animate='visible' variants={motionListItems}>
-                Small images are a focus with sizes that are often smaller than direct competitors. That includes language images.
+                Build, deploy, and run your applications with our general purpose and language stack container images.
               </motion.p>
             </div>
           </div>
@@ -121,14 +116,14 @@ export default function Home() {
               <p>Alternately, you can also use SLE BCI in a Dockerfile and build container images using your favorite container runtime</p>
             </div>
             <div className='flex flex-col gap-4'>
-              <a href='https://github.com/neuvector/neuvector-helm' target='_blank' rel='nofollow noreferrer' className='hover:scale-105 transition-all underline flex align-middle justify-center px-auto py-2 font-bold text-white bg-primary-light dark:text-secondary-dark dark:bg-primary hover:underline hover:cursor-pointer'>
-                Deploy Using Helm Charts
+            <a href='https://opensource.suse.com/bci-docs/guides/use-with-golang/' target='_blank' rel='nofollow noreferrer' className='hover:scale-105 transition-all underline flex align-middle justify-center px-auto py-2 font-bold text-white bg-primary-light dark:text-secondary-dark dark:bg-primary hover:underline hover:cursor-pointer'>
+                Build & deploy your applications
               </a>
-              <a href='https://open-docs.neuvector.com/deploying/kubernetes' target='_blank' rel='nofollow noreferrer' className='hover:scale-105 transition-all underline flex align-middle justify-center px-auto py-2 font-bold text-white bg-primary-light dark:text-secondary-dark dark:bg-primary hover:underline hover:cursor-pointer'>
-                Deploy on Kubernetes
+              <a href='https://opensource.suse.com/bci-docs/guides/vscode-dev-containers/' target='_blank' rel='nofollow noreferrer' className='hover:scale-105 transition-all underline flex align-middle justify-center px-auto py-2 font-bold text-white bg-primary-light dark:text-secondary-dark dark:bg-primary hover:underline hover:cursor-pointer'>
+                Use as a Dev Container
               </a>
-              <a href='https://open-docs.neuvector.com/deploying/production/operators ' target='_blank' rel='nofollow noreferrer' className='hover:scale-105 transition-all underline flex align-middle justify-center px-auto py-2 font-bold text-white bg-primary-light dark:text-secondary-dark dark:bg-primary hover:underline hover:cursor-pointer'>
-                OpenShift Operator
+              <a href='https://opensource.suse.com/bci-docs/guides/building-on-top-of-bci/' target='_blank' rel='nofollow noreferrer' className='hover:scale-105 transition-all underline flex align-middle justify-center px-auto py-2 font-bold text-white bg-primary-light dark:text-secondary-dark dark:bg-primary hover:underline hover:cursor-pointer'>
+                Build your own custom image
               </a>
             </div>
           </div>
@@ -139,14 +134,14 @@ export default function Home() {
             <div className='flex flex-col gap-4 p-8 bg-gray-400 dark:bg-secondary-dark'>
               <p className='text-2xl mb-4 text-left text-secondary-dark dark:text-primary'>How to get involved</p>
 
-              <p>OpenZeroTrust is an open source project hosted on GitHub.</p>
+              <p>SLE BCI is an open source project hosted on GitHub.</p>
               <p>Bugs and features are tracked through issues and new code is reviewed through pull requests.</p>
 
               <div className='grid grid-flow-row md:grid-cols-2 gap-4'>
-                <a href='https://github.com/neuvector ' target='_blank' rel='nofollow noreferrer' className='hover:scale-105 transition-all underline flex align-middle justify-center px-auto py-2 font-bold text-white bg-primary-light dark:text-secondary-dark dark:bg-primary hover:underline hover:cursor-pointer '>
+                <a href='https://github.com/SUSE/BCI-tests/issues' target='_blank' rel='nofollow noreferrer' className='hover:scale-105 transition-all underline flex align-middle justify-center px-auto py-2 font-bold text-white bg-primary-light dark:text-secondary-dark dark:bg-primary hover:underline hover:cursor-pointer '>
                   Issues
                 </a>
-                <a href='https://github.com/neuvector ' target='_blank' rel='nofollow noreferrer' className='hover:scale-105 transition-all underline flex align-middle justify-center px-auto py-2 font-bold text-white bg-primary-light dark:text-secondary-dark dark:bg-primary hover:underline hover:cursor-pointer '>
+                <a href='https://github.com/SUSE/BCI-tests/pulls' target='_blank' rel='nofollow noreferrer' className='hover:scale-105 transition-all underline flex align-middle justify-center px-auto py-2 font-bold text-white bg-primary-light dark:text-secondary-dark dark:bg-primary hover:underline hover:cursor-pointer '>
                   Pull Request
                 </a>
               </div>
@@ -161,7 +156,7 @@ export default function Home() {
                 <a href='https://slack.rancher.io/ ' target='_blank' rel='nofollow noreferrer' className='hover:scale-105 transition-all underline flex align-middle justify-center px-auto py-2 font-bold text-white bg-primary-light dark:text-secondary-dark dark:bg-primary hover:underline hover:cursor-pointer'>
                   Rancher Users Slack
                 </a>
-                <a href='https://github.com/neuvector ' target='_blank' rel='nofollow noreferrer' className='hover:scale-105 transition-all underline flex align-middle justify-center px-auto py-2 font-bold text-white bg-primary-light dark:text-secondary-dark dark:bg-primary hover:underline hover:cursor-pointer'>
+                <a href='https://github.com/SUSE/BCI-tests/issues ' target='_blank' rel='nofollow noreferrer' className='hover:scale-105 transition-all underline flex align-middle justify-center px-auto py-2 font-bold text-white bg-primary-light dark:text-secondary-dark dark:bg-primary hover:underline hover:cursor-pointer'>
                   Issues
                 </a>
               </div>


### PR DESCRIPTION
This PR does the following:
- Clean the homepage copy & add a button so that it looks as below
<img width="1512" alt="image" src="https://github.com/SUSE/bci/assets/21279125/c6e382db-1422-4559-9452-bd45e2947326">

- Amend the audit warnings for npm due to version. This is reflected in package.json.